### PR TITLE
Fix link to tekton.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If defined at the `Application` it will apply to all devices unless there is a p
 As a reference architecture, Drogue Ajour uses a Open Container Initiative (OCI) compatible registry to store container images with the device firmware. This allows reusing existing infrastructure commonly used in Kubernetes. However, Drogue Ajour also integrates with Eclipse Hawkbit for storing the firmware (see below).
 
 Building and deploying firmware is decoupled from the Drogue Ajour, as long as the expected manifest format can be retrieved from a firmware metadata (in case of containers, as a label on the container image). As a reference architecture,
-a [tekton](tekton.dev) pipeline is used to show how you can build and deploy firmware to a container registry.
+a [tekton](https://tekton.dev) pipeline is used to show how you can build and deploy firmware to a container registry.
 
 The Drogue IoT Application and Device objects contain custom properties that define the desired firmware version that each device (or all) should be served.
 ```


### PR DESCRIPTION
This commit updates the link to tekton.dev which currently results in a 404 Not Found.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>