### PR TITLE
Remove unused import

### DIFF
--- a/server/src/oci.rs
+++ b/server/src/oci.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 pub use client::{ClientConfig, ClientProtocol};
 use lru::LruCache;
 use oci_distribution::{client, secrets::RegistryAuth, Reference};
-use std::io::Read;
 use tokio::time::{Duration, Instant};
 
 pub struct OciClient {


### PR DESCRIPTION
Currently the following compiler warning is generated:
```console
warning: unused import: `std::io::Read`
 --> server/src/oci.rs:8:5
  |
8 | use std::io::Read;
  |     ^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```
This commit removes the unused import.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>