### PR TITLE
Remove unused BUNDLER_IMAGE param

### DIFF
--- a/deploy/pipeline/pipeline.yaml
+++ b/deploy/pipeline/pipeline.yaml
@@ -26,10 +26,6 @@ spec:
     - name: BUILDER_IMAGE
       description: Firmware builder image
       type: string
-    - name: BUNDLER_IMAGE 
-      description: Firmware bundler image
-      type: string
-      default: image-registry.openshift-image-registry.svc:5000/drogue-ajour/firmware-bundler:latest
     - description: Firmware image name
       name: IMAGE
       type: string


### PR DESCRIPTION
This commit removes the `BUNDLER_IMAGE` param as I think that it is no longer used. I think the `firmware-bundle` task was removed from the pipeline in Commit cc551220a483d85e7d29a89b15847687b757b84e ("Update to use ORAS for images").

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>